### PR TITLE
Parsing Update

### DIFF
--- a/Deprecated/interceptor.js
+++ b/Deprecated/interceptor.js
@@ -105,4 +105,3 @@ mo.observe(document, {subtree: true, childList: true});
 
 setTimeout( function() {sendToParser();}, 1500);
 
-

--- a/Javascript/Parser.js
+++ b/Javascript/Parser.js
@@ -41,9 +41,11 @@ function parseType(parseInfo)
 
         var numMatches = 0;
         var currEntry = supportedTypes[jsonEntry];
+        console.log("Current Entry functions: " + supportedTypes[jsonEntry].functions);
 
         for(var currFunc = 0; currFunc < currEntry.functions.length; currFunc++){
             if(funcList.includes(currEntry.functions[currFunc])){
+                console.log("Matched: " + currEntry.functions[currFunc]);
                 numMatches++;
             }
         }
@@ -51,9 +53,6 @@ function parseType(parseInfo)
             // possType becomes the most likely answer
             possType = currEntry.type;
             prevNumMatches = numMatches;
-
-            // if the number of matches matches the amount of functions defined for a type, then we've found it. break the loop
-            if(numMatches == currEntry.functions.length){ break; }
         }
         else if(numMatches != 0 && numMatches == prevNumMatches){
             console.log("Could either be type \'" + possType

--- a/Javascript/Parser.js
+++ b/Javascript/Parser.js
@@ -16,6 +16,7 @@ function parseType(parseInfo)
     //the modified D3 source code
     console.log(parseInfo.funcList);
     var funcList = [...parseInfo.funcList];
+    var argList = [...parseInfo.argList];
 
     //Default: Unsupported
     D3InfoObj.type = "unsupported";
@@ -27,7 +28,9 @@ function parseType(parseInfo)
     var possType;
     var funcListLen = funcList.length;
     var prevNumMatches = 0;
-    
+
+    console.log("Args passed: " + argList);
+
     //No D3 Code
     if(funcListLen == 0)
         possType = "none";

--- a/Javascript/Parser.js
+++ b/Javascript/Parser.js
@@ -28,6 +28,8 @@ function parseType(parseInfo)
     var possType;
     var funcListLen = funcList.length;
     var prevNumMatches = 0;
+    var prevDeviation = 5;
+    var matches = [];
 
     console.log("Args passed: " + argList);
 
@@ -51,7 +53,21 @@ function parseType(parseInfo)
         }
         if(numMatches > prevNumMatches){
             // possType becomes the most likely answer
+            var deviation = currentEntry.length - numMatches;
             possType = currEntry.type;
+
+            if(deviation < prevDeviation){
+                matches.push(possType);
+            }
+            else if(deviation == prevDeviation && numMatches > prevNumMatches){
+                matches = [];
+                matches.push(possType);
+                prevDeviation = deviation;
+            }
+            else if(deviation == prevDeviation && numMatches == prevNumMatches){
+                matches.push(possType);
+                prevDeviation = deviation
+            }
             prevNumMatches = numMatches;
         }
         else if(numMatches != 0 && numMatches == prevNumMatches){

--- a/Javascript/Parser.js
+++ b/Javascript/Parser.js
@@ -27,6 +27,12 @@ function parseType(parseInfo)
     var possType;
     var funcListLen = funcList.length;
     var prevNumMatches = 0;
+    
+    //No D3 Code
+    if(funcListLen == 0)
+        possType = "none";
+    else //Default: unsupported, gets overwritten if it is supported
+        possType = "unsupported";
 
     for(var jsonEntry = 0; jsonEntry < supportedTypes.length; jsonEntry++){
 

--- a/Javascript/Parser.js
+++ b/Javascript/Parser.js
@@ -56,21 +56,6 @@ function parseType(parseInfo)
     D3InfoObj.type = possType;
     sendToDB(D3InfoObj);
 
-    // If no substantial results are found from D3 scraping...
-    if(funcList.length == 0 || funcList == null || possType == undefined){
-        // check for an iframe. 
-        var iframes = document.getElementsByTagName('iframe');
-        if(!(iframes.length == 0)){
-            if(confirm("Could not locate a D3, should we open the iframe in a new tab?")){
-                window.open(iframes[0].src);
-            }
-            else{
-                console.log("User did not want to open the iframe.");
-            }
-        }
-        console.log("No D3 or iframe located.");
-    }
-
 }
 
 // Populates the parser with the JSON configuration file types that are currently supported

--- a/Javascript/Parser.js
+++ b/Javascript/Parser.js
@@ -18,9 +18,6 @@ function parseType(parseInfo)
     var funcList = [...parseInfo.funcList];
     var argList = [...parseInfo.argList];
 
-    //Default: Unsupported
-    D3InfoObj.type = "unsupported";
-
 
     //Logic:
     //waitForJson();
@@ -28,7 +25,7 @@ function parseType(parseInfo)
     var possType;
     var funcListLen = funcList.length;
     var prevNumMatches = 0;
-    var prevDeviation = 5;
+    var prevDeviation = 6;
     var matches = [];
 
     console.log("Args passed: " + argList);
@@ -39,44 +36,53 @@ function parseType(parseInfo)
     else //Default: unsupported, gets overwritten if it is supported
         possType = "unsupported";
 
-    for(var jsonEntry = 0; jsonEntry < supportedTypes.length; jsonEntry++){
-
+    for(var jsonEntry = 0; jsonEntry < supportedTypes.length; jsonEntry++)
+    {
         var numMatches = 0;
         var currEntry = supportedTypes[jsonEntry];
-        console.log("Current Entry functions: " + supportedTypes[jsonEntry].functions);
 
-        for(var currFunc = 0; currFunc < currEntry.functions.length; currFunc++){
-            if(funcList.includes(currEntry.functions[currFunc])){
-                console.log("Matched: " + currEntry.functions[currFunc]);
+        for(var currFunc = 0; currFunc < currEntry.functions.length; currFunc++)
+        {
+            if(funcList.includes(currEntry.functions[currFunc]))
                 numMatches++;
-            }
         }
-        if(numMatches > prevNumMatches){
-            // possType becomes the most likely answer
-            var deviation = currentEntry.length - numMatches;
-            possType = currEntry.type;
 
-            if(deviation < prevDeviation){
-                matches.push(possType);
-            }
-            else if(deviation == prevDeviation && numMatches > prevNumMatches){
-                matches = [];
-                matches.push(possType);
-                prevDeviation = deviation;
-            }
-            else if(deviation == prevDeviation && numMatches == prevNumMatches){
-                matches.push(possType);
-                prevDeviation = deviation
-            }
+        var deviation = currEntry.length - numMatches;
+        if(deviation < prevDeviation)
+        {
+            // possType becomes the most likely answer
+            prevDeviation = deviation;
             prevNumMatches = numMatches;
+            matches = [];
+            matches.push(currEntry.type);
         }
-        else if(numMatches != 0 && numMatches == prevNumMatches){
-            console.log("Could either be type \'" + possType
-             + "\' or \'" + currEntry.type);
+        else if(deviation == prevDeviation)
+        {
+            if(numMatches > prevNumMatches)
+            {
+                matches = [];
+                prevNumMatches = numMatches;
+                matches = [];
+                matches.push(currEntry.type);
+            }
+            else if(numMatches == prevNumMatches)
+                matches.push(currEntry.type);
         }
     }
 
-    console.log("It is likely: " + possType);
+    if(matches.length == 1)
+    {
+        possType = matches[0];
+        console.log("It is likely: " + possType);
+    }
+    else
+    {
+        var output = "Failed to parse type. Cannot differentiate this between";
+        for(let match of matches)
+            output += " " + match;
+        console.log(output);
+    }
+
     D3InfoObj.type = possType;
     sendToDB(D3InfoObj);
 

--- a/Javascript/SupportedTypes.json
+++ b/Javascript/SupportedTypes.json
@@ -78,9 +78,33 @@
         "arguments": []
     },
     {
-        "type": "hierarchial_bar_chart",
-        "functions": ["linear", "hierarchy"],
+        "type": "moving_averages",
+        "functions": ["scaleLinear", "scaleTime", "linear", "time", "range"],
+        "length": 5,
+        "arguments": []
+    },
+    {
+        "type": "density_contours",
+        "functions": ["contourDensity", "density"],
         "length": 2,
         "arguments": []
+    },
+    {
+        "type": "hexbin_chart",
+        "functions": ["hexbin"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "hexbin_chart",
+        "functions": ["hexbin"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "scatter_plot",
+        "functions": ["scaleLinear", "scaleLinear"],
+        "length": 2,
+        "arguments": ["circle", "cx", "cy"]
     }
 ]

--- a/Javascript/SupportedTypes.json
+++ b/Javascript/SupportedTypes.json
@@ -32,7 +32,7 @@
     {
         "type": "stacked_bar_chart",
         "functions": ["ordinal", "stack"],
-        "length": 1,
+        "length": 2,
         "arguments": []
     },
     {
@@ -74,7 +74,7 @@
     {
         "type": "moving_averages",
         "functions": ["scaleLinear", "scaleTime", "time", "range"],
-        "length": 5,
+        "length": 4,
         "arguments": []
     },
     {

--- a/Javascript/SupportedTypes.json
+++ b/Javascript/SupportedTypes.json
@@ -24,13 +24,13 @@
         "arguments": []
     },
     {
-        "type": "circle_pack",
+        "type": "circle_packing_chart",
         "functions": ["pack"],
         "length": 1,
         "arguments": []
     },
     {
-        "type": "difference_chart",
+        "type": "Difference Chart",
         "functions": ["area", "bisect"],
         "length": 2,
         "arguments": []
@@ -84,7 +84,7 @@
         "arguments": []
     },
     {
-        "type": "tree_map",
+        "type": "treemap",
         "functions": ["treemap"],
         "length": 1,
         "arguments": []

--- a/Javascript/SupportedTypes.json
+++ b/Javascript/SupportedTypes.json
@@ -1,42 +1,86 @@
 [
     {
         "type": "bar_chart",
-        "functions": ["linear"]
+        "functions": ["linear"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "scatter_plot",
-        "functions": ["keys"]
+        "functions": ["keys"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "line_chart",
-        "functions": ["line"]
+        "functions": ["line"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "pie_chart",
-        "functions": ["pie"]
+        "functions": ["pie"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "sequences_sunburst",
-        "functions": ["hierarchy"]
+        "functions": ["hierarchy"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "stacked_area_chart",
-        "functions": ["stack", "area"]
+        "functions": ["stack", "area"],
+        "length": 2,
+        "arguments": []
     },
     {
         "type": "stacked_bar_chart",
-        "functions": ["stack"]
+        "functions": ["stack"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "box_plot",
-        "functions": ["linear", "quantile"]
+        "functions": ["linear", "quantile"],
+        "length": 2,
+        "arguments": []
     },
     {
         "type": "histogram",
-        "functions": ["histogram"]
+        "functions": ["histogram"],
+        "length": 1,
+        "arguments": []
     },
     {
         "type": "candlestick_chart",
-        "functions": ["scaleQuantize"]
+        "functions": ["scaleQuantize"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "tree_map",
+        "functions": ["treemap"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "circle_pack",
+        "functions": ["pack"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "colored_line_chart",
+        "functions": ["line", "style"],
+        "length": 2,
+        "arguments": []
+    },
+    {
+        "type": "hierarchial_bar_chart",
+        "functions": ["linear", "hierarchy"],
+        "length": 2,
+        "arguments": []
     }
 ]

--- a/Javascript/SupportedTypes.json
+++ b/Javascript/SupportedTypes.json
@@ -1,7 +1,49 @@
 [
     {
+        "type": "area_chart",
+        "functions": ["area"],
+        "length": 1,
+        "arguments": []
+    },
+    {
         "type": "bar_chart",
-        "functions": ["linear"],
+        "functions": ["linear", "ordinal", "range", "axis", "max"],
+        "length": 5,
+        "arguments": []
+    },
+    {
+        "type": "box_plot",
+        "functions": ["quantile"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "candlestick_chart",
+        "functions": ["scaleQuantize"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "circle_pack",
+        "functions": ["pack"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "difference_chart",
+        "functions": ["area", "bisect"],
+        "length": 2,
+        "arguments": []
+    },
+    {
+        "type": "heatmap",
+        "functions": ["scaleSequential"],
+        "length": 1,
+        "arguments": []
+    },
+    {
+        "type": "histogram",
+        "functions": ["histogram"],
         "length": 1,
         "arguments": []
     },
@@ -18,9 +60,15 @@
         "arguments": []
     },
     {
+        "type": "scatter_plot",
+        "functions": ["linear", "axis", "keys"],
+        "length": 3,
+        "arguments": ["circle", "cx", "cy"]
+    },
+    {
         "type": "sequences_sunburst",
-        "functions": ["hierarchy"],
-        "length": 1,
+        "functions": ["hierarchy", "arc"],
+        "length": 2,
         "arguments": []
     },
     {
@@ -31,26 +79,8 @@
     },
     {
         "type": "stacked_bar_chart",
-        "functions": ["ordinal", "stack"],
-        "length": 2,
-        "arguments": []
-    },
-    {
-        "type": "box_plot",
-        "functions": ["linear", "quantile"],
-        "length": 2,
-        "arguments": []
-    },
-    {
-        "type": "histogram",
-        "functions": ["histogram"],
-        "length": 1,
-        "arguments": []
-    },
-    {
-        "type": "candlestick_chart",
-        "functions": ["scaleQuantize"],
-        "length": 1,
+        "functions": ["linear", "ordinal", "range", "axis", "max", "stack"],
+        "length": 6,
         "arguments": []
     },
     {
@@ -58,41 +88,5 @@
         "functions": ["treemap"],
         "length": 1,
         "arguments": []
-    },
-    {
-        "type": "circle_pack",
-        "functions": ["pack"],
-        "length": 1,
-        "arguments": []
-    },
-    {
-        "type": "colored_line_chart",
-        "functions": ["line", "style"],
-        "length": 2,
-        "arguments": []
-    },
-    {
-        "type": "moving_averages",
-        "functions": ["scaleLinear", "scaleTime", "time", "range"],
-        "length": 4,
-        "arguments": []
-    },
-    {
-        "type": "density_contours",
-        "functions": ["contourDensity", "density"],
-        "length": 2,
-        "arguments": []
-    },
-    {
-        "type": "hexbin_chart",
-        "functions": ["hexbin"],
-        "length": 1,
-        "arguments": []
-    },
-    {
-        "type": "scatter_plot",
-        "functions": ["linear", "scaleLinear", "scaleLinear", "keys"],
-        "length": 2,
-        "arguments": ["circle", "cx", "cy"]
     }
 ]

--- a/Javascript/SupportedTypes.json
+++ b/Javascript/SupportedTypes.json
@@ -6,12 +6,6 @@
         "arguments": []
     },
     {
-        "type": "scatter_plot",
-        "functions": ["keys"],
-        "length": 1,
-        "arguments": []
-    },
-    {
         "type": "line_chart",
         "functions": ["line"],
         "length": 1,
@@ -37,7 +31,7 @@
     },
     {
         "type": "stacked_bar_chart",
-        "functions": ["stack"],
+        "functions": ["ordinal", "stack"],
         "length": 1,
         "arguments": []
     },
@@ -79,7 +73,7 @@
     },
     {
         "type": "moving_averages",
-        "functions": ["scaleLinear", "scaleTime", "linear", "time", "range"],
+        "functions": ["scaleLinear", "scaleTime", "time", "range"],
         "length": 5,
         "arguments": []
     },
@@ -96,14 +90,8 @@
         "arguments": []
     },
     {
-        "type": "hexbin_chart",
-        "functions": ["hexbin"],
-        "length": 1,
-        "arguments": []
-    },
-    {
         "type": "scatter_plot",
-        "functions": ["scaleLinear", "scaleLinear"],
+        "functions": ["linear", "scaleLinear", "scaleLinear", "keys"],
         "length": 2,
         "arguments": ["circle", "cx", "cy"]
     }

--- a/Javascript/injector.js
+++ b/Javascript/injector.js
@@ -5,6 +5,7 @@
 //It has to be done this way because the original approach, messing with Localstorage, caused
 //issues logging into Canvas (which is admittedly kinda funny).
 var scriptText = `
+//Interceptor Code starts here, is injected.
 //Expert Goggles: Function Logger Tracks function calls from D3
 var funcLogger = {};
 funcLogger.funcsCalled = [];
@@ -111,39 +112,16 @@ mo.observe(document, {subtree: true, childList: true});
 
 
 setTimeout( function() {sendToParser();}, 1500);
-`
+`;
 
-if (!urlContent)
-{
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
-
-    xhr.onload = function(e)
-    {
-        if ((xhr.readyState === 4) && (xhr.status === 200))
-        {
-            localStorage.setItem(urlEncoded, xhr.responseText);
-            window.location.reload(true);
-        }
-    };
-
-    xhr.send(null);
-
-    document.write('<script src="' + url + '"><\/scr' + 'ipt>');
-}
-else
-{
-    var d3script = document.createElement("script");
-    //d3script.src = chrome.extension.getURL("Javascript/d3.js");
-    d3script.textContent = urlContent;
-    d3script.charset = "utf-8";
-    d3script.type = "text/javascript";
-    d3script.id = "ExpertGoggles";
-    d3script.setAttribute("async", "false");
-    document.documentElement.append(d3script);
-    localStorage.removeItem(urlEncoded);
-    console.log("Expert Goggles: Injected D3 Interception Script.");
-}
+var d3script = document.createElement("script");
+d3script.textContent = scriptText;
+d3script.charset = "utf-8";
+d3script.type = "text/javascript";
+d3script.id = "ExpertGoggles";
+d3script.setAttribute("async", "false");
+document.documentElement.append(d3script);
+console.log("Expert Goggles: Injected D3 Interception Script.");
 
 
 

--- a/Javascript/injector.js
+++ b/Javascript/injector.js
@@ -1,11 +1,117 @@
 //Inject Interceptor onto the page
 
-//Workaround to race condition
-//Recommended by Comments Section Addressing this Bug
-//https://bugs.chromium.org/p/chromium/issues/detail?id=634381
-var url = chrome.extension.getURL("Javascript/interceptor.js");
-var urlEncoded = window.btoa(unescape(encodeURIComponent(url)));
-var urlContent = localStorage.getItem(urlEncoded);
+//Code that is injected has to be a string literal here.
+//The original source file is at Deprecated/interceptor.js
+//It has to be done this way because the original approach, messing with Localstorage, caused
+//issues logging into Canvas (which is admittedly kinda funny).
+var scriptText = `
+//Expert Goggles: Function Logger Tracks function calls from D3
+var funcLogger = {};
+funcLogger.funcsCalled = [];
+funcLogger.argList = [];
+var alreadyFired = false;
+
+var needArgs = ["append", "attr"];
+
+//This is called to replace D3 functions with functions that log themselves but return the same thing
+funcLogger.replace = function(old_func, func_name)
+{
+    return function()
+    {
+        if(!funcLogger.funcsCalled.includes(func_name))
+            funcLogger.funcsCalled.push(func_name);
+
+        if(needArgs.includes(func_name) && arguments)
+        {
+            var argString = func_name + "(";
+            var count = 0;
+            for(let arg of arguments)
+            {
+                if(count > 0)
+                    argString += ", ";
+
+                 argString += arg.toString();
+                 count++;
+            }
+            argString += ")";
+            funcLogger.argList.push(argString);
+        }
+
+        return old_func.apply(this, arguments);
+    }
+}
+
+//Expert Goggles Interception: SendToParser()
+//sendToParser() Sends a list of tracked function from the injected script
+//back out to the extension's parser
+function sendToParser()
+{
+    if(!alreadyFired)
+        return;
+
+    //Generate an object with the necessary info, append funcList to it
+    var parseObj = {};
+    parseObj.funcList = funcLogger.funcsCalled;
+    parseObj.argList = funcLogger.argList;
+    parseObj.sender = "ExpertGoggles";
+
+    console.log("Expert Goggles Scraper: Sending message to background.");
+
+     //Message ParseObj out
+     try{window.postMessage(parseObj, "*");}
+     catch(err) {console.log(err)};
+
+}
+
+function interceptD3()
+{
+    if(alreadyFired)
+        return;
+
+    if(window.d3)
+    {
+        alreadyFired = true;
+        mo.disconnect();
+        console.log("Expert Goggles: Interceptor Fired.")
+
+        //Expert Goggles Interception: Add a logger to all functions
+        for(var name in window.d3)
+        {
+            var func = window.d3[name];
+            if(typeof func == "function") //Intercept functions
+                window.d3[name] = funcLogger.replace(func, name);
+            else //Intercept Subfunctions
+                for(var subName in window.d3[name])
+                {
+                    var subFunc = window.d3[name][subName]
+                    if(typeof subFunc == "function")
+                        window.d3[name][subName] = funcLogger.replace(subFunc, subName);
+                }
+
+        }
+    }
+}
+
+var count = 0;
+
+function callback(mutations)
+{
+    for(let m of mutations)
+    {
+        var newNode = m.addedNodes[0];
+        try
+        {
+            if(newNode.tagName == "SCRIPT")
+                interceptD3();
+        }catch(err){}
+    }
+}
+var mo = new MutationObserver(callback);
+mo.observe(document, {subtree: true, childList: true});
+
+
+setTimeout( function() {sendToParser();}, 1500);
+`
 
 if (!urlContent)
 {

--- a/Javascript/interceptor.js
+++ b/Javascript/interceptor.js
@@ -1,7 +1,10 @@
 //Expert Goggles: Function Logger Tracks function calls from D3
 var funcLogger = {};
 funcLogger.funcsCalled = [];
+funcLogger.argList = [];
 var alreadyFired = false;
+
+var needArgs = ["append", "attr"];
 
 //This is called to replace D3 functions with functions that log themselves but return the same thing
 funcLogger.replace = function(old_func, func_name)
@@ -10,6 +13,23 @@ funcLogger.replace = function(old_func, func_name)
     {
         if(!funcLogger.funcsCalled.includes(func_name))
             funcLogger.funcsCalled.push(func_name);
+
+        if(needArgs.includes(func_name) && arguments)
+        {
+            var argString = func_name + "(";
+            var count = 0;
+            for(let arg of arguments)
+            {
+                if(count > 0)
+                    argString += ", ";
+
+                 argString += arg.toString();
+                 count++;
+            }
+            argString += ")";
+            funcLogger.argList.push(argString);
+        }
+
         return old_func.apply(this, arguments);
     }
 }
@@ -25,6 +45,7 @@ function sendToParser()
     //Generate an object with the necessary info, append funcList to it
     var parseObj = {};
     parseObj.funcList = funcLogger.funcsCalled;
+    parseObj.argList = funcLogger.argList;
     parseObj.sender = "ExpertGoggles";
 
     console.log("Expert Goggles Scraper: Sending message to background.");


### PR DESCRIPTION
While we did not hit our goal of all 22 in the requirements document, we combined some subtypes into broader categories (treemaps covers 3 types listed in requirements), and also added some types that weren't required. Parsing Logic is more accurate than before, and uses a better approach that can be updated much more easily. 

As is, 15 types are supported, with some subtypes being captured in a more general category.